### PR TITLE
Add Mac OS X support to ndkBuild task

### DIFF
--- a/dabmpg123plugin/build.gradle
+++ b/dabmpg123plugin/build.gradle
@@ -29,14 +29,15 @@ android {
         String osName = org.gradle.internal.os.OperatingSystem.current().getName()
         if (org.gradle.internal.os.OperatingSystem.current().isLinux()) {
             commandLine "$ndkDir/ndk-build", '-C', file("$projectDir").absolutePath
+        } else if (org.gradle.internal.os.OperatingSystem.current().isMacOsX()) {
+            commandLine "$ndkDir/ndk-build", '-C', file("$projectDir").absolutePath
         } else if (org.gradle.internal.os.OperatingSystem.current().isUnix()) {
+            logger.error("ndk-build command line not defined for Unix")
             //TODO consider UNIX build
         } else if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
             commandLine "$ndkDir/ndk-build.cmd", '-C', file("$projectDir").absolutePath
-        } else if (org.gradle.internal.os.OperatingSystem.current().isMacOsX()) {
-            //TODO consider OSX build
         } else {
-            //unknown OS...Ooops...
+            logger.error("Unknown OS")
         }
     }
 


### PR DESCRIPTION
The function `isUnix()` returns true for Mac systems, thus the check for Mac OS X must come before the check for Unix.

The command line from Linux was copied to the Mac OS X case and builds without issue.

Logger error messages were added to the Unix and unknown OS cases. Without these messages builds would fail with a non specific `execCommand == null!` message with little to indicate the source of the error.